### PR TITLE
raptor2: rebumped

### DIFF
--- a/libs/raptor2/DETAILS
+++ b/libs/raptor2/DETAILS
@@ -1,12 +1,12 @@
           MODULE=raptor2
-         VERSION=2.0.7
+         VERSION=2.0.8
           SOURCE=$MODULE-$VERSION.tar.gz
    SOURCE_URL[0]=http://download.librdf.org/source
    SOURCE_URL[1]=$SFORGE_URL/librdf
-      SOURCE_VFY=sha1:b9a8ce3e2c30c3318b402667f3d7573771ae731d
+      SOURCE_VFY=sha1:6caec62d28dbf5bc26e8de5a46101b52aabf94fd
         WEB_SITE=http://librdf.org/raptor
          ENTERED=20040102
-         UPDATED=20120327
+         UPDATED=20120628
            SHORT="C library that parses RDF syntaxes"
 
 cat << EOF


### PR DESCRIPTION
I don't know if the whole KDE workspace works with this,
but 2.0.8 was around in the old moonbase and didn't produce
any errors over here.
