### PR TITLE
Submission by Mark Turner

### DIFF
--- a/development/qyoto/DEPENDS
+++ b/development/qyoto/DEPENDS
@@ -1,6 +1,7 @@
 depends kde-baseapps
 depends mono
 depends smokegen
+depends smokeqt
 
 optional_depends phonon      "-DWITH_Phonon=ON"      "-DWITH_Phonon=OFF"      "for phonon support"
 optional_depends qimageblitz "-DWITH_QImageBlitz=ON" "-DWITH_QImageBlitz=OFF" "for graphics support"


### PR DESCRIPTION
qyoto: fails to build without smokeqt... updated depends.

updated depends to include smokeqt, otherwise this module fails to build.
