### PR TITLE
qt-creator: this does not need kde around

### DIFF
--- a/qt4-apps/qt-creator/BUILD
+++ b/qt4-apps/qt-creator/BUILD
@@ -1,7 +1,6 @@
 (
 
   source /etc/profile.d/qt4.rc &&
-  source /etc/profile.d/kde4.rc &&
 
   QT_CREATOR_BLD="$SOURCE_DIRECTORY/creator-build" &&
 


### PR DESCRIPTION
This was pointed out by Rainbowcrypt on IRC
