### PR TITLE
calibre: add missing dependency

### DIFF
--- a/qt4-apps/calibre/DEPENDS
+++ b/qt4-apps/calibre/DEPENDS
@@ -14,3 +14,4 @@ depends cssutils
 depends chmlib
 depends podofo
 depends apsw
+depends cssselect


### PR DESCRIPTION
required for book conversion
