### PR TITLE
phonon: it depends on kde4.rc...

### DIFF
--- a/utils/phonon/BUILD
+++ b/utils/phonon/BUILD
@@ -1,5 +1,3 @@
-(
-
   export CFLAGS="$CFLAGS -fPIC"  &&
 
   source /etc/profile.d/qt4.rc   &&
@@ -11,5 +9,3 @@
 
   # needed by kde-baseapps, kipi-plugins, kmldonkey and possible other modules
   ln -sf /usr/lib/libphonon.so.4  /usr/lib/qt4/libphonon.so
-
-) > $C_FIFO 2>&1

--- a/utils/phonon/DEPENDS
+++ b/utils/phonon/DEPENDS
@@ -1,3 +1,5 @@
+depends makeobj
+
 optional_depends "glib-2"        "-DWITH_GLIB2=ON"       "-DWITH_GLIB2=OFF"      "for glib-2 support"
 optional_depends "pulseaudio"    "-DWITH_PulseAudio=ON"  "-DWITH_PulseAudio=OFF" "for pulseaudio audio support"
 optional_depends "libqzeitgeist" "-DWITH_QZeitgeist=ON"  "-DWITH_QZeitgeist=OFF" "for logging of activities and events (Recommended)"


### PR DESCRIPTION
... which is provided by makeobj. phonon is an optional dependency of
kde-base, so we have to add this dependency directly.
