### PR TITLE
kdepim: fix qt4's moc with kdepim

### DIFF
--- a/office/kdepim/BUILD
+++ b/office/kdepim/BUILD
@@ -1,8 +1,5 @@
-(
 
   source /etc/profile.d/qt4.rc   &&
   source /etc/profile.d/kde4.rc  &&
 
   default_cmake_build
-  
-) > $C_FIFO 2>&1

--- a/office/kdepim/PRE_BUILD
+++ b/office/kdepim/PRE_BUILD
@@ -1,0 +1,4 @@
+default_pre_build &&
+
+# qt4's moc chokes on BOOST_JOIN
+grep -l -r "#include <boost/.*>" | xargs sed -i "s@.*include <boost/.*>.*@#ifndef Q_MOC_RUN\n\0\n#endif@"


### PR DESCRIPTION
qt4's moc can't handle preprocessor variables which are used in a
(growing) number of boost headers. This makes moc ignore all boost includes
and therefore is future proof although a bit verbose...
