### PR TITLE
korundum: fix build with ruby 2.2.0

### DIFF
--- a/development/korundum/PRE_BUILD
+++ b/development/korundum/PRE_BUILD
@@ -1,0 +1,4 @@
+default_pre_build &&
+
+# RUBY_VERSION_PATCH might not be defined
+sedit '/compute an overall/ i if(NOT RUBY_VERSION_PATCH)\nset(RUBY_VERSION_PATCH 0)\nendif(NOT RUBY_VERSION_PATCH)' CMakeLists.txt


### PR DESCRIPTION
When 0 it seems ruby doesn't set RUBY_VERSION_PATCH at all.