### PR TITLE
phonon: fix build with qt5 & gcc 5

### DIFF
--- a/utils/phonon/PRE_BUILD
+++ b/utils/phonon/PRE_BUILD
@@ -1,0 +1,4 @@
+default_pre_build &&
+
+# credit goes to the gentoo devs
+sedit 's@set(CMAKE_POSITION_INDEPENDENT_CODE ON)@set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_COMPILE_OPTIONS_PIC}")@' cmake/FindPhononInternal.cmake


### PR DESCRIPTION
The problem came up because qt5 requires -fPIC but cmake assumes
PIE is enough (and damn, it should be).