### PR TITLE
qt5: bump to qt5.6 PLEASE MERGE

### DIFF
--- a/qt5/DETAILS
+++ b/qt5/DETAILS
@@ -1,16 +1,18 @@
           MODULE=qt5
-         VERSION=5.5.1
+         VERSION=5.6.0
           SOURCE=qt-everywhere-opensource-src-$VERSION.tar.xz
          SOURCE2=qt5-chromium-with-libjpeg.patch.bz2
+         SOURCE3=qt5-webengine-nss.patch
       SOURCE_URL=http://download.qt-project.org/official_releases/qt/${VERSION%.*}/$VERSION/single
      SOURCE2_URL=$PATCH_URL
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/qt-everywhere-opensource-src-$VERSION
-      SOURCE_VFY=sha256:6f028e63d4992be2b4a5526f2ef3bfa2fe28c5c757554b11d9e8d86189652518
+      SOURCE_VFY=sha256:76a95cf6c1503290f75a641aa25079cd0c5a8fcd7cff07ddebff80a955b07de7
      SOURCE2_VFY=sha256:d3c9a6288f086d1de57f82a18b5e95b0ce2ed9331a091799a350d3c7b6fc3c6e
+     SOURCE3_VFY=sha256:21acec764e2bfbc84aaf93cbf011bc604346f52661eb7f7621e9f67cc7872efe
    MODULE_PREFIX=${QT5_PREFIX:-/usr}
-        WEB_SITE=http://www.trolltech.com/qt
+        WEB_SITE=http://qt-project.org
          ENTERED=20140822
-         UPDATED=20151025
+         UPDATED=20160411
            SHORT="A C++ toolkit for application development"
 cat << EOF
 Qt is a C++ toolkit for application development. It lets application

--- a/qt5/PRE_BUILD
+++ b/qt5/PRE_BUILD
@@ -15,6 +15,9 @@ fi &&
 # this fixes qt5 with system jpeg - jpeg-turbo works fine without it!
 patch_it $SOURCE2 1 &&
 
+( cd qtwebengine; patch_it $SOURCE3 1 ) &&
+
+
 # fix build with previous version of the module installed
 # see https://bugreports.qt.io/browse/QTBUG-33948 and related
 sedit "s@\(QMAKE_LFLAGS_RPATH *=\) \(.*\)@\1 -Wl,-enable-new-dtags \2@" qtbase/mkspecs/common/gcc-base-unix.conf &&


### PR DESCRIPTION
Current qt5 doesn't build anymore because it is incompatible with the current
nss release.

Now qt5 HAS to be rebuilt as icu4c got bumped.

Please merge this soon.