### PR TITLE
qtwebkit: fix build with an --as-needed system

### DIFF
--- a/qt5-apps/qtwebkit/BUILD
+++ b/qt5-apps/qtwebkit/BUILD
@@ -1,14 +1,5 @@
 
-  patch_it $SOURCE2 1 &&
-  patch_it $SOURCE3 1 &&
-
   . /etc/profile.d/qt5.rc &&
-
-  sed -i -e '/SUBDIRS += examples/d' Source/QtWebKit.pro &&
-  sed -i -e '/CONFIG +=/s/rpath//' \
-		Source/WebKit/qt/declarative/{experimental/experimental,public}.pri \
-		Tools/qmake/mkspecs/features/{force_static_libs_as_shared,unix/default_post}.prf &&
-
   /usr/lib/qt5/bin/qmake $OPTS &&
 
   default_make

--- a/qt5-apps/qtwebkit/PRE_BUILD
+++ b/qt5-apps/qtwebkit/PRE_BUILD
@@ -1,0 +1,13 @@
+default_pre_build &&
+
+patch_it $SOURCE2 1 &&
+patch_it $SOURCE3 1 &&
+
+
+sedit '/SUBDIRS += examples/d' Source/QtWebKit.pro &&
+sedit '/CONFIG +=/s/rpath//' \
+		Source/WebKit/qt/declarative/{experimental/experimental,public}.pri \
+		Tools/qmake/mkspecs/features/{force_static_libs_as_shared,unix/default_post}.prf &&
+
+# underlinked with --as-needed
+sedit '$ a LIBS += -pthread' Source/api.pri


### PR DESCRIPTION
also moved all patching to PRE_BUILD,
where it belongs.