### PR TITLE
qt4: don't rebuild pinentry in POST_INSTALL

### DIFF
--- a/qt4-apps/qt4/POST_INSTALL
+++ b/qt4-apps/qt4/POST_INSTALL
@@ -1,4 +1,1 @@
 ld_add /usr/lib/qt4
-if module_installed pinentry; then
-  lin -c pinentry
-fi


### PR DESCRIPTION
pinentry now depends on qt5 and lin in POST_INSTALL is bad practice anyway.