### PR TITLE
PyQt5: re-enable sip files

### DIFF
--- a/qt5-apps/PyQt5/BUILD
+++ b/qt5-apps/PyQt5/BUILD
@@ -1,5 +1,4 @@
 OPTS+=" --no-timestamp \
-        --no-sip-files \
         --assume-shared \
         --confirm-license \
         --qmake=/usr/lib/qt5/bin/qmake" &&


### PR DESCRIPTION
These are required by calibre.