### PR TITLE
PyQt5: re-enable sip files

### DIFF
--- a/qt5-apps/calibre/DEPENDS
+++ b/qt5-apps/calibre/DEPENDS
@@ -15,6 +15,7 @@ depends podofo
 depends apsw
 depends cssselect
 depends netifaces
+depends libmtp
 
 # for running external viewers
 depends xdg-utils


### PR DESCRIPTION
These are required by calibre.