### PR TITLE
PyQt5: version bump

### DIFF
--- a/qt5-apps/PyQt5/DETAILS
+++ b/qt5-apps/PyQt5/DETAILS
@@ -1,13 +1,13 @@
           MODULE=PyQt5
-         VERSION=5.7
+         VERSION=5.7.1
           SOURCE=$MODULE\_gpl-$VERSION.tar.gz
       SOURCE_URL=$SFORGE_URL/pyqt/PyQt5/PyQt-$VERSION/
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/PyQt5_gpl-$VERSION
    MODULE_PREFIX=${QT5_PREFIX:-/usr}
-      SOURCE_VFY=sha256:892693ba5f79989abb2061dad2d5c4e6f127e9dd3240f73f8220c7152cd35b05
+      SOURCE_VFY=sha256:be849f212a074049b9ebc10b6c07dddefb86e6d30e8df8a5c715cbb2cf7fad14
         WEB_SITE=http://www.riverbankcomputing.com/software/pyqt/
          ENTERED=20141111
-         UPDATED=20160807
+         UPDATED=20170208
            SHORT="Python bindings for Qt 5.x"
 
 cat << EOF


### PR DESCRIPTION
The old version produces a segfault when trying to build our calibre module.