### PR TITLE
extra-cmake-modules: version bump to 5.40.0

### DIFF
--- a/frameworks/extra-cmake-modules/DETAILS
+++ b/frameworks/extra-cmake-modules/DETAILS
@@ -1,8 +1,8 @@
           MODULE=extra-cmake-modules
-         VERSION=5.31.0
+         VERSION=5.40.0
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=http://download.kde.org/stable/frameworks/${VERSION%.*}
-      SOURCE_VFY=sha256:84271a59045468ced64823f030d3dc9f157cec16a30387483ec888639fdc2deb
+      SOURCE_VFY=sha256:83e48889c84474e4f560e10e4eea0cc529f8511b3bd0415fcb898ac0496e630a
    MODULE_PREFIX=${KDE4_INSTALL_DIR:-/usr}
         WEB_SITE=https://projects.kde.org/projects/kdesupport/extra-cmake-modules
          ENTERED=20150205


### PR DESCRIPTION
The repo for version 5.31.0 no longer exists