### PR TITLE
PyQt5: sips are required!

### DIFF
--- a/qt5-apps/PyQt5/BUILD
+++ b/qt5-apps/PyQt5/BUILD
@@ -1,10 +1,6 @@
 . /etc/profile.d/qt5.rc &&
 
-# For qt5-5.10.0 support
-sedit "s:Qt_5_9_3}:Qt_5_9_3 Qt_5_10_0 Qt_5_10_1}:" sip/QtCore/QtCoremod.sip &&
-
 OPTS+=" --no-timestamp \
-        --no-sip-files \
         --no-dist-info \
         --assume-shared \
         --confirm-license \


### PR DESCRIPTION
Things that build sip python bindings that depend on PyQt
will simply fail if these files are not there.

Installing PyQt5 without sips is
like installing libpyqt5 without libpyqt5-dev.

We are not Debian.