### PR TITLE
qwt-6: install to share/doc

### DIFF
--- a/qt5-apps/qwt-6/BUILD
+++ b/qt5-apps/qwt-6/BUILD
@@ -4,7 +4,7 @@
 #  for i in `ls src/*.h` ; do sedit "s:qwt_global.h :qwt-6/qwt_global.h:" $i ; done &&
 
   sedit "s:/usr/local/qwt-\$\$QWT_VERSION:/usr:" qwtconfig.pri &&
-  sedit "s:/doc:/doc/$MODULE:" qwtconfig.pri &&
+  sedit "s:/doc:/share/doc/$MODULE:" qwtconfig.pri &&
   sedit "s:/include:/include/qwt:" qwtconfig.pri &&
   sedit "s:/lib:/lib/$MODULE:" qwtconfig.pri &&
   sedit "s:plugins/designer:/lib/$MODULE/plugins/designer/$MODULE:" qwtconfig.pri &&


### PR DESCRIPTION
fails here because it installs its docs in /usr/doc.
(Why did I find this only now?...)