### PR TITLE
qt5: if user select NOT to intsall qtwebengine then don't build qtlocation too

### DIFF
--- a/system/qt5/CONFIGURE
+++ b/system/qt5/CONFIGURE
@@ -2,6 +2,6 @@ mquery BUILD_EXAMPLES   "Build examples?${PROBLEM_COLOR} Needed by phonon for qt
 mquery BUILD_TOOLS      "Build tools? ${PROBLEM_COLOR}Needed by phonon for qt5 support and provides the designer stuff needed by some frameworks/apps and qtdeclarative${DEFAULT_COLOR}" y "-make tools" "-nomake tools"
 mquery SYS_PROXY        "Use system network proxies by default?" n "-system-proxies" "-no-system-proxies"
 mquery QML_DEBUG        "Build the QML debugging support?${PROBLEM_COLOR} Needed by kdeclarative${DEFAULT_COLOR}" y "-qml-debug" "-no-qml-debug"
-mquery SKIP_QTWEBENGINE "Build the qtwebengine?" y "" "-skip qtwebengine"
+mquery SKIP_QTWEBENGINE "Build the qtwebengine?" y "" "-skip qtwebengine -skip qtlocation"
 mquery USE_JOURNALD     "Send logging output to journald?" n
 mquery LICENSE_TYPE     "Build Qt using open-source license? (n=commercial)" y


### PR DESCRIPTION
this will reduce both compilation time and space needed for a complete qt5 build
although someone may find the qtlocation build NOT really related with qtwebengine