### PR TITLE
plasma-workspace: missing depends, fix typo

### DIFF
--- a/apps/kmymoney/DEPENDS
+++ b/apps/kmymoney/DEPENDS
@@ -1,4 +1,6 @@
 depends libalkimia
+depends kdiagram
+depends kdewebkit
 
 optional_depends libofx "--enable-ofxplugin --enable-ofxbanking" "" "for OFX plugin support" y
 optional_depends aqbanking  "" "" "For additional banking support" y

--- a/plasma/plasma-workspace/DEPENDS
+++ b/plasma/plasma-workspace/DEPENDS
@@ -44,7 +44,9 @@ depends kitemviews
 depends solid
 depends sonnet
 depends baloo
+depends ksysguard
+depends kwin
 
 optional_depends gpsd "" "" "for geolocation support"
 optional_depends networkmanager-qt "" "" "for newwork manager support"
-optional_depends kde-cli-tools "" "" "For better interaction with the system{PROBLEM_COLOR}, say no on first install of plasma-workspace.${DEFAULT_COLOR}"
+optional_depends kde-cli-tools "" "" "For better interaction with the system, ${PROBLEM_COLOR} say no on first install of plasma-workspace.${DEFAULT_COLOR}"


### PR DESCRIPTION
added ksysguard and kwin to depends, fixed missing '$' in {PROBLEM_COLOR} notification.