### PR TITLE
qt-creator: DEPENDS update

### DIFF
--- a/development/qt-creator/DEPENDS
+++ b/development/qt-creator/DEPENDS
@@ -6,4 +6,4 @@ optional_depends bzr  "" "" "for bazaar support"
 
 optional_depends mercurial "" "" "for mercurial support"
 
-optional_depends openssh-askpass "" "" "for SSH support"
+optional_depends ksshaskpass "" "" "for SSH support"


### PR DESCRIPTION
openssh-askpass no longer exists in the moonbase

switching to ksshaskpass is a logical replacement.