### PR TITLE
scribus - poppler patches

### DIFF
--- a/office/scribus/patch.d/scribus-1.5.6-docdir.patch
+++ b/office/scribus/patch.d/scribus-1.5.6-docdir.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists_Directories.cmake b/CMakeLists_Directories.cmake
+index db6133f..faf85ce 100644
+--- a/CMakeLists_Directories.cmake
++++ b/CMakeLists_Directories.cmake
+@@ -36,14 +36,16 @@ else()
+ endif()
+ 
+ #SHARE - use the default on Apple as TAG_VERSION is empty
+-if(WIN32 OR OS2)
+-	set(DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/")
+-elseif(TAG_VERSION OR BUILD_OSX_BUNDLE)
+-	set(DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/${MAIN_DIR_NAME}${TAG_VERSION}/")
+-elseif(NOT WANT_VERSIONING)
+-	set(DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/${MAIN_DIR_NAME}/")
+-else()
+-	set(DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/${MAIN_DIR_NAME}-${VERSION}/")
++if(NOT DOCDIR)
++	if(WIN32 OR OS2)
++		set(DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/")
++	elseif(TAG_VERSION OR BUILD_OSX_BUNDLE)
++		set(DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/${MAIN_DIR_NAME}${TAG_VERSION}/")
++	elseif(NOT WANT_VERSIONING)
++		set(DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/${MAIN_DIR_NAME}/")
++	else()
++		set(DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/${MAIN_DIR_NAME}-${VERSION}/")
++	endif()
+ endif()
+ 
+ if(IS_ABSOLUTE ${DOCDIR} AND WANT_RELOCATABLE)

--- a/office/scribus/patch.d/scribus-1.5.6.1-poppler-21.03.0-1.patch
+++ b/office/scribus/patch.d/scribus-1.5.6.1-poppler-21.03.0-1.patch
@@ -1,0 +1,53 @@
+From 7ce0ac16fd42d61ef9082b27822c7d9d79c7fef7 Mon Sep 17 00:00:00 2001
+From: Jean Ghali <jghali@libertysurf.fr>
+Date: Mon, 1 Mar 2021 21:52:54 +0000
+Subject: [PATCH] Attempt to fix build of pdf import plugin with poppler
+ 21.03.0
+
+git-svn-id: svn://scribus.net/trunk/Scribus@24537 11d20701-8431-0410-a711-e3c959e3b870
+---
+ scribus/plugins/import/pdf/slaoutput.cpp | 12 +++++++++++-
+ scribus/plugins/import/pdf/slaoutput.h   |  4 ++++
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/scribus/plugins/import/pdf/slaoutput.cpp b/scribus/plugins/import/pdf/slaoutput.cpp
+index 7cbc73e8d4..d1b37a0c21 100644
+--- a/scribus/plugins/import/pdf/slaoutput.cpp
++++ b/scribus/plugins/import/pdf/slaoutput.cpp
+@@ -2292,9 +2292,19 @@ GBool SlaOutputDev::patchMeshShadedFill(GfxState *state, GfxPatchMeshShading *sh
+ 	return gTrue;
+ }
+ 
+-GBool SlaOutputDev::tilingPatternFill(GfxState *state, Gfx * /*gfx*/, Catalog *cat, Object *str, POPPLER_CONST_070 double *pmat, int paintType, int tilingType, Dict *resDict, POPPLER_CONST_070 double *mat, POPPLER_CONST_070 double *bbox, int x0, int y0, int x1, int y1, double xStep, double yStep)
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(21, 3, 0)
++bool SlaOutputDev::tilingPatternFill(GfxState *state, Gfx * /*gfx*/, Catalog *cat, GfxTilingPattern *tPat, const double *mat, int x0, int y0, int x1, int y1, double xStep, double yStep)
++#else
++GBool SlaOutputDev::tilingPatternFill(GfxState *state, Gfx * /*gfx*/, Catalog *cat, Object *str, POPPLER_CONST_070 double *pmat, int /*paintType*/, int /*tilingType*/, Dict *resDict, POPPLER_CONST_070 double *mat, POPPLER_CONST_070 double *bbox, int x0, int y0, int x1, int y1, double xStep, double yStep)
++#endif
+ {
+ //	qDebug() << "SlaOutputDev::tilingPatternFill";
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(21, 3, 0)
++	const double *bbox = tPat->getBBox();
++	const double *pmat = tPat->getMatrix();
++	Dict *resDict = tPat->getResDict();
++#endif
++
+ 	PDFRectangle box;
+ 	Gfx *gfx;
+ 	QString id;
+diff --git a/scribus/plugins/import/pdf/slaoutput.h b/scribus/plugins/import/pdf/slaoutput.h
+index 5149f19e31..66c34203ae 100644
+--- a/scribus/plugins/import/pdf/slaoutput.h
++++ b/scribus/plugins/import/pdf/slaoutput.h
+@@ -197,7 +197,11 @@ class SlaOutputDev : public OutputDev
+ 	void stroke(GfxState *state) override;
+ 	void fill(GfxState *state) override;
+ 	void eoFill(GfxState *state) override;
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(21, 3, 0)
++	bool tilingPatternFill(GfxState *state, Gfx *gfx, Catalog *cat, GfxTilingPattern *tPat, const double *mat, int x0, int y0, int x1, int y1, double xStep, double yStep) override;
++#else
+ 	GBool tilingPatternFill(GfxState *state, Gfx *gfx, Catalog *cat, Object *str, POPPLER_CONST_070 double *pmat, int paintType, int tilingType, Dict *resDict, POPPLER_CONST_070 double *mat, POPPLER_CONST_070 double *bbox, int x0, int y0, int x1, int y1, double xStep, double yStep) override;
++#endif
+ 	GBool functionShadedFill(GfxState * /*state*/, GfxFunctionShading * /*shading*/) override { qDebug() << "Function Shaded Fill";  return gFalse; }
+ 	GBool axialShadedFill(GfxState *state, GfxAxialShading *shading, double tMin, double tMax) override;
+ 	GBool axialShadedSupportExtend(GfxState *state, GfxAxialShading *shading)  override { return (shading->getExtend0() == shading->getExtend1()); }

--- a/office/scribus/patch.d/scribus-1.5.6.1-poppler-21.03.0-2.patch
+++ b/office/scribus/patch.d/scribus-1.5.6.1-poppler-21.03.0-2.patch
@@ -1,0 +1,27 @@
+From 6b9ff916959bcb941866f0bd86da639a421337f8 Mon Sep 17 00:00:00 2001
+From: Jean Ghali <jghali@libertysurf.fr>
+Date: Mon, 1 Mar 2021 22:00:02 +0000
+Subject: [PATCH] Attempt to fix build of pdf import plugin with poppler
+ 21.03.0
+
+git-svn-id: svn://scribus.net/trunk/Scribus@24538 11d20701-8431-0410-a711-e3c959e3b870
+---
+ scribus/plugins/import/pdf/slaoutput.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/scribus/plugins/import/pdf/slaoutput.cpp b/scribus/plugins/import/pdf/slaoutput.cpp
+index d1b37a0c21..de0a4145ef 100644
+--- a/scribus/plugins/import/pdf/slaoutput.cpp
++++ b/scribus/plugins/import/pdf/slaoutput.cpp
+@@ -2336,7 +2336,11 @@ GBool SlaOutputDev::tilingPatternFill(GfxState *state, Gfx * /*gfx*/, Catalog *c
+ 	// Unset the clip path as it is unrelated to the pattern's coordinate space.
+ 	QPainterPath savedClip = m_currentClipPath;
+ 	m_currentClipPath = QPainterPath();
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(21, 3, 0)
++	gfx->display(tPat->getContentStream());
++#else
+ 	gfx->display(str);
++#endif
+ 	m_currentClipPath = savedClip;
+ 	inPattern--;
+ 	gElements = m_groupStack.pop();

--- a/office/scribus/patch.d/scribus-1.5.6.1-poppler-21.04.0.patch
+++ b/office/scribus/patch.d/scribus-1.5.6.1-poppler-21.04.0.patch
@@ -1,0 +1,27 @@
+From c62844064cd6d85802d21e188b0f479463e22095 Mon Sep 17 00:00:00 2001
+From: Jean Ghali <jghali@libertysurf.fr>
+Date: Sun, 4 Apr 2021 21:37:04 +0000
+Subject: [PATCH] #16536: Page::getFormWidgets() returns unique_ptr in poppler
+ 21.04.0
+
+git-svn-id: svn://scribus.net/trunk/Scribus@24599 11d20701-8431-0410-a711-e3c959e3b870
+---
+ scribus/plugins/import/pdf/slaoutput.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/scribus/plugins/import/pdf/slaoutput.h b/scribus/plugins/import/pdf/slaoutput.h
+index 66c34203ae..cb191b1023 100644
+--- a/scribus/plugins/import/pdf/slaoutput.h
++++ b/scribus/plugins/import/pdf/slaoutput.h
+@@ -379,7 +379,11 @@ class SlaOutputDev : public OutputDev
+ 	Catalog *catalog {nullptr};
+ 	SplashFontEngine *m_fontEngine {nullptr};
+ 	SplashFont *m_font {nullptr};
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(21, 4, 0)
++	std::unique_ptr<FormPageWidgets> m_formWidgets;
++#else
+ 	FormPageWidgets *m_formWidgets {nullptr};
++#endif
+ 	QHash<QString, QList<int> > m_radioMap;
+ 	QHash<int, PageItem*> m_radioButtons;
+ 	int m_actPage;


### PR DESCRIPTION
Four patches lifted from gentoo:
- One patch (docdir.patch) that properly closes an if statement.
- Three patches to ensure poppler compatability - scribus breaks without it.