### PR TITLE
PyQt5 - circular dependency

### DIFF
--- a/libs/PyQt5/DEPENDS
+++ b/libs/PyQt5/DEPENDS
@@ -1,5 +1,4 @@
 depends qt5
-depends qscintilla2
 depends python-dbus
 depends PyQt5_sip
 depends PyQt-builder


### PR DESCRIPTION
There's a circular dependency with PyQt5 and qscintilla2 - both of them list list the other as a dependency.
However, qscintilla2 is _not_ a requirement to compile PyQt5, so this is easily fixed by removing the _depends_
