### PR TITLE
qca - fix DEPENDS

### DIFF
--- a/libs/qca/DEPENDS
+++ b/libs/qca/DEPENDS
@@ -6,6 +6,12 @@ depends nss
 depends pkcs11-helper
 depends qt5
 
-optional_depends ca-certificates "" "" "use system certificates" y
+optional_depends ca-certificates \
+   "" \
+   "" \
+   "Use system certificates" y
 
-optional_depends Botan  "-DWITH_botan_PLUGIN=yes" "-DWITH_botan_PLUGIN=no" "For botan crypto cupport"
+optional_depends Botan  \
+   "" \
+   "" \
+   "For botan crypto cupport"


### PR DESCRIPTION
The existing configuration option for Botan (-DWITH_botan_PLUGIN) doesn't actually exist in qca - maybe it was an option in an older version?

- qca gives a warning message about the bad config option, but installs without problems - Botan is detected and used automatically.
- I've fixed the _optional_depends_ for Botan, and reformatted _ca_certificates_ for consistency.