### PR TITLE
plasma-workspace - fix depends

### DIFF
--- a/plasma/plasma-workspace/DEPENDS
+++ b/plasma/plasma-workspace/DEPENDS
@@ -44,9 +44,9 @@ depends kitemviews
 depends solid
 depends sonnet
 depends baloo
-depends ksystemstats
 depends kwin
 depends prison
+depends ktexteditor
 
 optional_depends gpsd "" "" "for geolocation support"
 optional_depends networkmanager-qt "" "" "for newwork manager support"

--- a/plasma/plasma-workspace/DETAILS
+++ b/plasma/plasma-workspace/DETAILS
@@ -6,7 +6,7 @@
    MODULE_PREFIX=${KDE4_INSTALL_DIR:-/usr}
         WEB_SITE=https://projects.kde.org/projects/kde/workspace/$MODULE
          ENTERED=20151123
-         UPDATED=20210831
+         UPDATED=20220123
            SHORT="KDE Plasma Workspace"
 
 cat << EOF

--- a/plasma/plasma-workspace/DETAILS
+++ b/plasma/plasma-workspace/DETAILS
@@ -6,7 +6,7 @@
    MODULE_PREFIX=${KDE4_INSTALL_DIR:-/usr}
         WEB_SITE=https://projects.kde.org/projects/kde/workspace/$MODULE
          ENTERED=20151123
-         UPDATED=20211130
+         UPDATED=20210831
            SHORT="KDE Plasma Workspace"
 
 cat << EOF


### PR DESCRIPTION
DEPENDS:
 - does not actually require _ksystemstats_
 - _does_ require _ktexteditor_ (build fails without it)

DETAILS:
 - update UPDATED