### PR TITLE
kuserfeerback, depends of plasma-workspace

### DIFF
--- a/frameworks/kuserfeedback/DEPENDS
+++ b/frameworks/kuserfeedback/DEPENDS
@@ -1,0 +1,1 @@
+depends extra-cmake-modules

--- a/frameworks/kuserfeedback/DETAILS
+++ b/frameworks/kuserfeedback/DETAILS
@@ -1,0 +1,15 @@
+          MODULE=kuserfeedback
+         VERSION=1.2.0
+          SOURCE=$MODULE-$VERSION.tar.xz
+      SOURCE_URL=$KDE_URL/stable/$MODULE/
+      SOURCE_VFY=sha256:76aac922b153249b274680a6f4c72c238ef14e3df04bad00cb64158b1063f264
+   MODULE_PREFIX=${KDE4_INSTALL_DIR:-/usr}
+        WEB_SITE=https://projects.kde.org/projects/kde/workspace/kuserfeedback
+         ENTERED=20151123
+         UPDATED=20220224
+           SHORT="KDE Framework for collecting user feedback for apps via telemetry and surveys "
+            TYPE=cmake
+
+cat << EOF
+Framework for collecting user feedback for apps via telemetry and surveys
+EOF

--- a/frameworks/kuserfeedback/DETAILS
+++ b/frameworks/kuserfeedback/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha256:76aac922b153249b274680a6f4c72c238ef14e3df04bad00cb64158b1063f264
    MODULE_PREFIX=${KDE4_INSTALL_DIR:-/usr}
         WEB_SITE=https://projects.kde.org/projects/kde/workspace/kuserfeedback
-         ENTERED=20151123
+         ENTERED=20220224
          UPDATED=20220224
            SHORT="KDE Framework for collecting user feedback for apps via telemetry and surveys "
             TYPE=cmake


### PR DESCRIPTION
New module - now required by _plasma-workspace,_ build of 5.22 fails without it.

Module description from KDE:
KDE Framework for collecting user feedback for apps via telemetry and surveys