### PR TITLE
plasma-workspace, update DEPENDS

### DIFF
--- a/plasma/plasma-workspace/DEPENDS
+++ b/plasma/plasma-workspace/DEPENDS
@@ -51,6 +51,7 @@ depends kscreen
 depends networkmanager-qt
 depends libksysguard
 depends kuserfeedback
+depends libqalculate
 
 optional_depends gpsd "" "" "for geolocation support"
 optional_depends kde-cli-tools "" "" "For better interaction with the system, ${PROBLEM_COLOR} say no on first install of plasma-workspace.${DEFAULT_COLOR}"

--- a/plasma/plasma-workspace/DEPENDS
+++ b/plasma/plasma-workspace/DEPENDS
@@ -47,7 +47,10 @@ depends baloo
 depends kwin
 depends prison
 depends ktexteditor
+depends kscreen
+depends networkmanager-qt
+depends libksysguard
+depends kuserfeedback
 
 optional_depends gpsd "" "" "for geolocation support"
-#optional_depends networkmanager-qt "" "" "for newwork manager support"
 optional_depends kde-cli-tools "" "" "For better interaction with the system, ${PROBLEM_COLOR} say no on first install of plasma-workspace.${DEFAULT_COLOR}"


### PR DESCRIPTION
Yet more dependencies for _plasma-workspace._ It won't build without them.
- networkmanager-qt is a hard dep, so I removed the _optional,_ which was commented out anyway (?)

**IMPORTANT:** there's a PR for a new module submitted - _kuserfeedback._ It needs to be approved before this will work. Check that out first.